### PR TITLE
Make library.properties specification compliant

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,7 +3,8 @@ author=Bruno Luiz
 email=Bruno Luiz da Silva <contato@brunoluiz.net>
 sentence=RestServer for Arduino
 paragraph=Arduino Rest Server 'route-oriented'
+category=Communication
 url=https://github.com/brnluiz/arduino-rest-server
 architectures=avr
-version=1.00
+version=1.0
 core-dependencies=arduino (>=1.5.0)


### PR DESCRIPTION
`version` value of 1.00 caused the warning on library installation and when Library Manager was opened/closed:
```
Invalid version found: 1.00
```
Missing `category` property caused the warning on every compilation:
```
WARNING: Category '' in library RestServer is not valid. Setting to 'Uncategorized'
```
Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification